### PR TITLE
liten endring i docker-compose for mobil gps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      ASPNETCORE_URLS: http://+:8080
+      ASPNETCORE_URLS: "http://0.0.0.0:8080"
       ASPNETCORE_ENVIRONMENT: Development
       # Important: use the service name "db" inside the Compose network
       ConnectionStrings__DefaultConnection: server=db;port=3306;database=nrl;user=root;password=rootpass


### PR DESCRIPTION
Hvorfor denne endringen: Geolocation i mobilnettlesere krever HTTPS. Det funket på PC (localhost), men ikke på telefon.

Hva jeg gjorde:

Lot appen fortsette å kjøre lokalt på HTTP 8080 i Docker.

Satte opp en fast ngrok-adresse  som peker til http://127.0.0.1:8080, så vi får HTTPS utad:

ngrok http --domain=<vårt>.ngrok-free.dev http://127.0.0.1:8080

Det fungerte ikke først fordi den ble forvirret og lyttet bare på IPv6, mens vår side er på IPv4. Så jeg endret en linje i docker-compose for å binde den til IPv4 med ASPNETCORE_URLS=http://0.0.0.0:8080 og lot ngrok peke eksplisitt til 127.0.0.1.

Slik tester du:

docker compose up --build

Start ngrok-tunnelen (kommando over)

Åpne den HTTPS-adressen på mobil → trykk Start GPS og godkjenn posisjon

Kartet følger posisjonen din, og lat/lng blir lagret når du oppretter en rapport