### PR TITLE
details added to reports view, final version I hope

### DIFF
--- a/WebApplication1/Controllers/ObstacleController.cs
+++ b/WebApplication1/Controllers/ObstacleController.cs
@@ -333,6 +333,7 @@ namespace WebApplication1.Controllers
                 ImagePath = validatedData.ImagePath,
                 ObstacleRegistrationTime = validatedData.ObstacleRegistrationTime,
                 IsDraft = report.IsDraft,
+                ObstacleHasLight = validatedData.ObstacleHasLight,
                 ReportID = report.ReportID // FK
             };
 

--- a/WebApplication1/Models/Entities/ReportItem.cs
+++ b/WebApplication1/Models/Entities/ReportItem.cs
@@ -42,6 +42,8 @@ namespace WebApplication1.Models
 
         public bool IsDraft { get; set; } = false;
 
+        public bool HasLights { get; set; }
+
         [StringLength(255)]
         public string? ImagePath { get; set; }
 

--- a/WebApplication1/Views/Reports/Details.cshtml
+++ b/WebApplication1/Views/Reports/Details.cshtml
@@ -65,8 +65,16 @@
             </div>
             <div class="grid gap-6 px-6 py-4 md:grid-cols-2">
                 <div>
+                    <p class="text-sm font-semibold text-gray-700">Report ID</p>
+                    <p class="text-gray-800">@Model.ReportObstacle.ObstacleID</p>
+                </div>
+                <div>
                     <p class="text-sm font-semibold text-gray-700">Name</p>
                     <p class="text-gray-800">@Model.ReportObstacle.ObstacleName</p>
+                </div>
+                <div>
+                    <p class="text-sm font-semibold text-gray-700">Type of obstacle</p>
+                    <p class="text-gray-800">@Model.ReportObstacle.ObstacleType</p>
                 </div>
                 <div>
                     <p class="text-sm font-semibold text-gray-700">Height (m)</p>
@@ -79,6 +87,10 @@
                 <div>
                     <p class="text-sm font-semibold text-gray-700">Longitude</p>
                     <p class="text-gray-800">@Model.ReportObstacle.ObstacleLongitude</p>
+                </div>
+                <div>
+                    <p class="text-sm font-semibold text-gray-700">Has lights</p>
+                    <p class="text-gray-800">@(Model.ReportObstacle.ObstacleHasLight ? "Yes" : "No")</p>
                 </div>
                 <div class="md:col-span-2">
                     <p class="text-sm font-semibold text-gray-700">Description</p>

--- a/WebApplication1/Views/Reports/Index.cshtml
+++ b/WebApplication1/Views/Reports/Index.cshtml
@@ -99,9 +99,12 @@
                 <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                         <tr>
+                            <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Report ID</th>
                             <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Date</th>
+                            <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Obstacle Type</th>
                             <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Title</th>
                             <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Status</th>
+                            <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Submitted by</th>
                             <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Organization</th>
                             <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Height (m)</th>
                             <th class="px-3 py-2 text-left text-xs font-medium tracking-wider text-gray-600 uppercase">Coordinates</th>                  
@@ -116,9 +119,17 @@
                         @foreach (var r in Model.Reports)
                         {
                             var obstacle = r.ReportObstacle;
+                                
                             <tr class="hover:bg-gray-50">
+                                <td class="px-3 py-2 text-sm whitespace-nowrap text-gray-800">
+                                    @(obstacle?.ObstacleID)
+                                </td>
                                 <td class="px-3 py-2 text-sm whitespace-nowrap text-gray-700">
                                     @r.CreatedAt.ToLocalTime().ToString("dd.MM.yyyy HH:mm")
+                                </td>
+
+                                <td class="px-3 py-2 text-sm whitespace-nowrap text-gray-800">
+                                    @(obstacle?.ObstacleType)
                                 </td>
 
                                 <td class="px-3 py-2 text-sm whitespace-nowrap text-gray-800">
@@ -139,6 +150,10 @@
                                             badge = "bg-gray-50 text-gray-800 border border-gray-200";                                           
                                     }
                                     <span class="rounded px-2 py-1 text-xs @badge">@status</span>
+                                </td>
+
+                                <td class="px-3 py-2 text-sm whitespace-nowrap text-gray-700">
+                                    @(r.CreatedBy ?? "Unknown")
                                 </td>
 
                                 <td class="px-3 py-2 text-sm whitespace-nowrap text-gray-700">
@@ -237,7 +252,7 @@
                                     *@
                                 }
                             </tr>
-                        }
+                            }
                     </tbody>
                 </table>
             }


### PR DESCRIPTION
Lagt til detaljene ReportID, obstacle type, has lights og submitted by i reports.index viewet, også oppdatert så detaljene viser i details viewet.

Ønsker å få endret layout på siden, da den nå må slide frem og tilbake for å se alle detaljer når rapportene ikke er filtrert. Dette vil også gjøre reports-siden mer mobil- og tabletvennlig for piloter som vil se over egne rapporter, men det får komme senere.