### PR TITLE
fjernet feilmeldingen Rania fikk under brukertest + la til egendefine…

### DIFF
--- a/WebApplication1/Controllers/ObstacleController.cs
+++ b/WebApplication1/Controllers/ObstacleController.cs
@@ -253,6 +253,7 @@ namespace WebApplication1.Controllers
                 ValidateSubmissionRequirements(validatedData);
                 if (!ModelState.IsValid)
                 {
+                    ViewBag.ErrorMessage = "Please fill all required fields before submitting.";
                     ViewBag.IsEditing = false;
                     ViewBag.ReportStatus = "Draft";
                     ViewBag.ReviewMessage = string.Empty;

--- a/WebApplication1/Controllers/ObstacleController.cs
+++ b/WebApplication1/Controllers/ObstacleController.cs
@@ -63,8 +63,11 @@ namespace WebApplication1.Controllers
             }
             if (!report.IsDraft && string.Equals(report.Status, "Approved", StringComparison.OrdinalIgnoreCase))
             {
-                TempData["ErrorMessage"] = "Approved reports cannot be edited.";
-                return RedirectToAction("Index", "Reports");
+                ViewBag.IsEditing = false;
+                ViewBag.ReadOnly = true;
+                return View(report.ReportObstacle);
+                //TempData["ErrorMessage"] = "Approved reports cannot be edited."; -> Gammel kode som ikke lar piloter åpne apporoved rapporter for visning
+                //return RedirectToAction("Index", "Reports");
             }
 
             var normalizedEmail = email.Trim().ToLowerInvariant();

--- a/WebApplication1/Models/ValidatedObstacleData.cs
+++ b/WebApplication1/Models/ValidatedObstacleData.cs
@@ -13,7 +13,7 @@ namespace WebApplication1.Models
         public new string? ObstacleName { get; set; }
 
         [Required(ErrorMessage = "Obstacle Height is required")]
-        [Range(0, 200, ErrorMessage = "Height must be between 0 and 200 meters")]
+        [Range(0, 1000, ErrorMessage = "Height must be between 0 and 1000 meters")]
         public new double? ObstacleHeight { get; set; }
 
         [Required(ErrorMessage = "Obstacle Description is required")]

--- a/WebApplication1/Views/Obstacle/DataForm.cshtml
+++ b/WebApplication1/Views/Obstacle/DataForm.cshtml
@@ -85,6 +85,14 @@
                 Only pilots can create or save obstacle reports. You can review the form, but submissions will be rejected.
             </div>
         }
+   
+        @if (ViewBag.ErrorMessage != null)
+        {
+            <div class="status-warning-top text-center mx-auto">
+                <strong>⚠ Warning:</strong> @ViewBag.ErrorMessage
+            </div>
+        }
+
         <h1 class="text-2xl sm:text-3xl font-bold mb-6 text-center">
             @(isEditing ? "Edit Obstacle Report" : "Obstacle Registration Form")
         </h1>
@@ -99,6 +107,9 @@
                 }
             </div>
         }
+
+ 
+
 
         <!-- Form -->
         <form asp-controller="Obstacle" asp-action="DataForm" method="post" enctype="multipart/form-data" class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/WebApplication1/Views/Obstacle/DataForm.cshtml
+++ b/WebApplication1/Views/Obstacle/DataForm.cshtml
@@ -54,6 +54,7 @@
 @{
 
     bool isEditing = ViewBag.IsEditing != null && (bool)ViewBag.IsEditing;
+    bool readOnly = ViewBag.ReadOnly != null && (bool)ViewBag.ReadOnly;
 
     bool isDraft = Model?.IsDraft ?? true;
     string reportStatus = ViewBag.ReportStatus as string ?? (isDraft ? "Draft" : "Pending");
@@ -72,7 +73,8 @@
         statusBadge = "bg-orange-100 text-orange-800";
     }
 
-    bool disableEditing = isEditing && !isDraft && !reportStatus.Equals("More info required", StringComparison.OrdinalIgnoreCase);
+    // bool disableEditing = isEditing && !isDraft && !reportStatus.Equals("More info required", StringComparison.OrdinalIgnoreCase);
+    bool disableEditing = readOnly || (isEditing && !isDraft && !reportStatus.Equals("More info required", StringComparison.OrdinalIgnoreCase));
 }
 
 <div class="flex-container">
@@ -232,10 +234,35 @@
     </div>
 </div>
 
-@if (disableEditing)
+@{
+    string disableMessage = string.Empty; // The warning message to display when editing is disabled
+    
+    // Set the disable message based on report status
+    if (disableEditing)
+    {
+        if(reportStatus.Equals("Approved",StringComparison.OrdinalIgnoreCase))
+        {
+            disableMessage = "This obstacle report has been approved and cannot be edited.";
+        }
+        else if (reportStatus.Equals("Rejected",StringComparison.OrdinalIgnoreCase))
+        {
+            disableMessage = "This obstacle report has been rejected and cannot be edited.";
+        }
+        else if (reportStatus.Equals("Pending", StringComparison.OrdinalIgnoreCase))
+        {
+            disableMessage = "You cannot edit this obstacle report because it has already been submitted for review";
+        }
+        else
+        {
+            disableMessage = "You cannot edit this obstacle report.";
+        }   
+    }
+}
+
+@if (disableEditing) // Show warning if editing is disabled
 {
-    <div class="status-warning-top">
-        <strong>⚠ Warning:</strong> You cannot edit this obstacle report because it has already been submitted for review.
+    <div class="status-warning-top text-center mx-auto">
+        <strong>⚠ Warning:</strong> @disableMessage
     </div>
 
     <script>
@@ -248,6 +275,7 @@
         });
     </script>
 }
+
 
 <script>
     var disableEditing = @disableEditing.ToString().ToLower(); // Pass Disable Editing flag to JavaScript as boolean

--- a/WebApplication1/Views/Obstacle/DataForm.cshtml
+++ b/WebApplication1/Views/Obstacle/DataForm.cshtml
@@ -158,13 +158,13 @@
 
             <div class="sm:col-span-2">
                 <label asp-for="ObstacleName" class="block mb-1 font-medium text-gray-700 required">Obstacle Name</label>
-                <input asp-for="ObstacleName" class="w-full border border-gray-300 rounded p-2" placeholder="e.g., Wall, Ramp" />
+                <input asp-for="ObstacleName" class="w-full border border-gray-300 rounded p-2" placeholder="e.g., Wall, Ramp (max 100 characters)" />
                 <span asp-validation-for="ObstacleName"></span>
             </div>
 
             <div class="sm:col-span-2">
                 <label asp-for="ObstacleHeight" class="block mb-1 font-medium text-gray-700">Obstacle Height (meters)</label>
-                <input asp-for="ObstacleHeight" type="number" step="any" class="w-full border border-gray-300 rounded p-2" placeholder="e.g., 2.5" />
+                <input asp-for="ObstacleHeight" type="number" step="any" class="w-full border border-gray-300 rounded p-2" placeholder="e.g., 2.5 (0-1000 m)" />
 
                 <div class="text-gray-500 text-sm mb-4">
                     Obstacles ≥15 m must be registered (≥30 m in densely built areas).<br>
@@ -176,7 +176,7 @@
 
             <div class="sm:col-span-2">
                 <label asp-for="ObstacleDescription" class="block mb-1 font-medium text-gray-700 required">Obstacle Description</label>
-                <textarea asp-for="ObstacleDescription" class="w-full border border-gray-300 rounded p-2 h-96" placeholder="Describe the obstacle, meterials, location, etc."></textarea>
+                <textarea asp-for="ObstacleDescription" class="w-full border border-gray-300 rounded p-2 h-96" placeholder="Describe the obstacle, meterials, location, etc. (max 1000 characters)"></textarea>
                 <span asp-validation-for="ObstacleDescription"></span>
             </div>
 

--- a/WebApplication1/Views/Reports/Index.cshtml
+++ b/WebApplication1/Views/Reports/Index.cshtml
@@ -228,7 +228,7 @@
                                             else
                                             {
                                                 <a class="button-white-blue inline-block px-3 py-2 text-xs"
-                                                    href="@Url.Action("Dataform", "Obstacle", new { id = r.ReportID })">
+                                                    href="@Url.Action("DataForm", "Obstacle", new { id = r.ReportID })">
                                                     View
                                                 </a>                                                                                                
                                             }


### PR DESCRIPTION
<img width="1488" height="421" alt="Skjermbilde 2025-11-26 191431" src="https://github.com/user-attachments/assets/51e06e4c-e2a5-45df-ba73-1d55bc7aaa97" />

- fjernet feilmeldingen Rania fikk under brukertesten. Pilot skal kunne se approved rapporter uten å få feimelding (se vedlagt bilde for tidligere feil)
- la til egendefinerte meldingsvarsler ut ifra rapportens status (se kode for type melding på div report status) 

UPDATE
- la til varsel melding hvis bruker prøver submit rapport uten å fylle required fields 
- endret validerings grense på høyde fra 200-1000 meter etter tilbakemelding fra pilot under expo + la til ekstra tekst i placeholders